### PR TITLE
Fix bridge handling, leak-protection setup, and release packaging checks

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
@@ -42,6 +44,9 @@ jobs:
         run: |
           chmod +x download-deps.sh
           bash download-deps.sh
+
+      - name: Test
+        run: dotnet test OnionHop/OnionHopV3.sln -c Release
 
       - name: Publish app (linux-x64, self-contained)
         run: |
@@ -98,13 +103,16 @@ jobs:
           wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
           chmod +x appimagetool
           ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool OnionHop.AppDir OnionHop-x86_64.AppImage
+          sha256sum OnionHop-x86_64.AppImage | tee OnionHop-x86_64.AppImage.sha256.txt
           ls -lh OnionHop-x86_64.AppImage
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: OnionHop-x86_64.AppImage
-          path: OnionHop-x86_64.AppImage
+          path: |
+            OnionHop-x86_64.AppImage
+            OnionHop-x86_64.AppImage.sha256.txt
           if-no-files-found: error
 
       - name: Attach to release
@@ -114,4 +122,4 @@ jobs:
         run: |
           TAG="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}"
           echo "Attaching AppImage to release $TAG"
-          gh release upload "$TAG" OnionHop-x86_64.AppImage --repo "${{ github.repository }}" --clobber
+          gh release upload "$TAG" OnionHop-x86_64.AppImage OnionHop-x86_64.AppImage.sha256.txt --repo "${{ github.repository }}" --clobber

--- a/.github/workflows/linux-cli.yml
+++ b/.github/workflows/linux-cli.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
@@ -39,6 +41,9 @@ jobs:
         run: |
           chmod +x download-deps.sh
           bash download-deps.sh
+
+      - name: Test
+        run: dotnet test OnionHop/OnionHopV3.sln -c Release
 
       - name: Publish CLI (linux-x64, self-contained)
         run: |
@@ -81,4 +86,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}"
-          gh release upload "$TAG" OnionHopCLI-*-linux-x64.tar.gz --repo "${{ github.repository }}" --clobber
+          gh release upload "$TAG" OnionHopCLI-*-linux-x64.tar.gz OnionHopCLI-*-linux-x64.tar.gz.sha256.txt --repo "${{ github.repository }}" --clobber

--- a/.github/workflows/windows-portable.yml
+++ b/.github/workflows/windows-portable.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
@@ -43,6 +45,10 @@ jobs:
       - name: Download native dependencies (tor, transports, sing-box, xray, wintun, ArtiHop)
         shell: pwsh
         run: .\download-deps.ps1 -NoPause
+
+      - name: Test
+        shell: pwsh
+        run: dotnet test OnionHop\OnionHopV3.sln -c Release
 
       - name: Build portable package
         shell: pwsh
@@ -77,4 +83,4 @@ jobs:
         run: |
           $tag = if ('${{ github.event_name }}' -eq 'release') { '${{ github.event.release.tag_name }}' } else { '${{ inputs.release_tag }}' }
           $zip = (Get-ChildItem installer\output\OnionHopV3-Portable-*-win-x64.zip | Select-Object -First 1).FullName
-          gh release upload "$tag" "$zip" --repo "${{ github.repository }}" --clobber
+          gh release upload "$tag" "$zip" "$zip.sha256.txt" --repo "${{ github.repository }}" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+Fixes
+- Fixed Windows admin-helper status probing so persistent-helper connection validation cannot deadlock or hang indefinitely.
+- Fixed cancellation handling in dependency and bridge fetch paths.
+- Fixed custom vanilla bridge lines so they are not rewritten as a fake `custom` transport.
+- Fixed Arti/ArtiHop bridge transport arguments so Conjure and Snowflake launch with their required PT flags.
+- Fixed Linux/Windows DNS and Linux kill-switch setup to report failure when system rules are not actually installed.
+- Fixed relay, logs, bridge scanner, and custom DoH UI states.
+
+Packaging
+- CLI publish now includes optional ArtiHop and Snowflake runtime folders.
+- Release workflows run tests before packaging and upload checksum files with release assets.
+
 ## v2.4.4 (2026-03-03)
 
 Additions

--- a/OnionHop/README.md
+++ b/OnionHop/README.md
@@ -1,37 +1,36 @@
-# OnionHop V3 (Avalonia + SukiUI)
+# OnionHop V3
 
-This is the **V3 UI** for OnionHop, rebuilt with **Avalonia** + **SukiUI** for a cleaner, modern, cross-platform UI.
+OnionHop V3 is the Avalonia + FluentAvalonia desktop client and CLI for routing traffic through Tor, bridges, and TUN/VPN mode.
 
 ## Status
 
-- GUI releases: **Windows + macOS**
-- Windows: **GUI + CLI**
-- macOS: **GUI release available** (no CLI package yet)
-- Linux: **source/build support is present**, packaged release still pending
+- GUI releases: Windows, Linux AppImage, and macOS from the dedicated macOS release repo.
+- CLI releases: Windows and Linux.
+- Target framework: .NET 9.
 
 ## Build
 
 ```powershell
-dotnet build "OnionHop/OnionHopV2.sln" -c Release
+dotnet build "OnionHop/OnionHopV3.sln" -c Release
 ```
 
-## Run
+## Run GUI
 
 ```powershell
 dotnet run --project "OnionHop/src/OnionHopV3.App" -c Release
 ```
 
-On first connect, the app will ensure the required Tor/VPN dependencies are available for the active platform.
+On first connect, the app ensures the required Tor/VPN dependencies are available for the active platform.
 
 ## Run CLI
 
 ```powershell
-dotnet run --project "OnionHop/src/OnionHopV2.Cli" -c Release
+dotnet run --project "OnionHop/src/OnionHopV3.Cli" -c Release
 ```
 
 CLI quick start:
 
-```powershell
+```text
 connect --smart on
 countries
 connect --smart off --exit us --entry nl
@@ -39,21 +38,27 @@ status
 disconnect
 ```
 
-## Build CLI Installer (Windows)
+## Packaging
+
+Windows installer:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File installer/build-installer-cli.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File installer/build-installer-v3.ps1
 ```
 
-## Build Portable Packages (Windows)
-
-GUI portable ZIP:
+Windows GUI portable ZIP:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File installer/build-portable-v3.ps1
 ```
 
-CLI portable ZIP:
+Windows CLI installer:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File installer/build-installer-cli.ps1
+```
+
+Windows CLI portable ZIP:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File installer/build-portable-cli.ps1

--- a/OnionHop/src/OnionHopV3.App/Styles/V3Theme.axaml
+++ b/OnionHop/src/OnionHopV3.App/Styles/V3Theme.axaml
@@ -146,6 +146,26 @@
     <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
   </Style>
 
+  <Style Selector="Button.ActionSecondary">
+    <Setter Property="Background" Value="{DynamicResource ControlFillColorDefaultBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+  </Style>
+  <Style Selector="Button.ActionSecondary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
+  </Style>
+
+  <Style Selector="Button.ActionGhost">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+  </Style>
+  <Style Selector="Button.ActionGhost:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+  </Style>
+
   <Style Selector="Button.ActionDanger">
     <Setter Property="Background" Value="{DynamicResource SystemFillColorCriticalBackgroundBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource SystemFillColorCriticalBrush}" />

--- a/OnionHop/src/OnionHopV3.App/ViewModels/BridgeScannerPageViewModel.cs
+++ b/OnionHop/src/OnionHopV3.App/ViewModels/BridgeScannerPageViewModel.cs
@@ -79,43 +79,46 @@ public sealed partial class BridgeScannerPageViewModel : PageViewModelBase
             return;
         }
 
-        IReadOnlyList<string> candidates;
-        if (UseCustomBridges)
-        {
-            candidates = SplitLines(CustomBridges);
-            if (candidates.Count == 0)
-            {
-                ProgressText = "Paste at least one bridge line first.";
-                return;
-            }
-        }
-        else
-        {
-            ProgressText = "Fetching bridge list…";
-            var fetch = await BridgeSourceService
-                .FetchAsync(SelectedCategory, SelectedTransport, SelectedIpVersion, null, State.AppendLog, CancellationToken.None)
-                .ConfigureAwait(true);
-            if (fetch == null || fetch.Lines.Count == 0)
-            {
-                ProgressText = "Could not fetch bridges from any mirror. Check your connection or paste custom bridges.";
-                State.AppendLog("Bridge scanner: all bridge-source mirrors failed.");
-                return;
-            }
-
-            candidates = fetch.Lines;
-        }
-
-        ResetState(candidates.Count);
         IsScanning = true;
         _scanCts = new CancellationTokenSource();
-        State.AppendLog($"Bridge scanner: probing {candidates.Count} {SelectedTransport} bridge(s) " +
-                        $"({SelectedCategory}, {SelectedIpVersion}) with {Workers} worker(s), {TimeoutSeconds}s timeout.");
-
-        // Progress<T> captures the UI SynchronizationContext here, so OnResult runs on the UI thread.
-        var progress = new Progress<BridgeScanResult>(OnResult);
+        var scanStarted = false;
 
         try
         {
+            IReadOnlyList<string> candidates;
+            if (UseCustomBridges)
+            {
+                candidates = SplitLines(CustomBridges);
+                if (candidates.Count == 0)
+                {
+                    ProgressText = "Paste at least one bridge line first.";
+                    return;
+                }
+            }
+            else
+            {
+                ProgressText = "Fetching bridge list...";
+                var fetch = await BridgeSourceService
+                    .FetchAsync(SelectedCategory, SelectedTransport, SelectedIpVersion, null, State.AppendLog, _scanCts.Token)
+                    .ConfigureAwait(true);
+                if (fetch == null || fetch.Lines.Count == 0)
+                {
+                    ProgressText = "Could not fetch bridges from any mirror. Check your connection or paste custom bridges.";
+                    State.AppendLog("Bridge scanner: all bridge-source mirrors failed.");
+                    return;
+                }
+
+                candidates = fetch.Lines;
+            }
+
+            ResetState(candidates.Count);
+            scanStarted = true;
+            State.AppendLog($"Bridge scanner: probing {candidates.Count} {SelectedTransport} bridge(s) " +
+                            $"({SelectedCategory}, {SelectedIpVersion}) with {Workers} worker(s), {TimeoutSeconds}s timeout.");
+
+            // Progress<T> captures the UI SynchronizationContext here, so OnResult runs on the UI thread.
+            var progress = new Progress<BridgeScanResult>(OnResult);
+
             await BridgeScanService
                 .ScanAsync(candidates, Workers, TimeSpan.FromSeconds(TimeoutSeconds), progress, _scanCts.Token)
                 .ConfigureAwait(true);
@@ -135,7 +138,10 @@ public sealed partial class BridgeScannerPageViewModel : PageViewModelBase
             IsScanning = false;
             _scanCts?.Dispose();
             _scanCts = null;
-            UpdateSummary(final: true);
+            if (scanStarted)
+            {
+                UpdateSummary(final: true);
+            }
         }
     }
 

--- a/OnionHop/src/OnionHopV3.App/ViewModels/LogsPageViewModel.cs
+++ b/OnionHop/src/OnionHopV3.App/ViewModels/LogsPageViewModel.cs
@@ -98,6 +98,7 @@ public sealed partial class LogsPageViewModel : PageViewModelBase
         {
             SourceDns => "dns",
             SourceEngine => State.TunCoreMode == AppStateViewModel.TunCoreXray ? "xray" : "sing-box",
+            SourceBridges => "bridges",
             _ => "app"
         };
     }
@@ -108,6 +109,7 @@ public sealed partial class LogsPageViewModel : PageViewModelBase
         OnPropertyChanged(nameof(IsAppSelected));
         OnPropertyChanged(nameof(IsDnsSelected));
         OnPropertyChanged(nameof(IsEngineSelected));
+        OnPropertyChanged(nameof(IsBridgesSelected));
         OnPropertyChanged(nameof(ActiveSourcesSummary));
         RebuildVisibleEntries();
     }
@@ -372,6 +374,7 @@ public sealed partial class LogsPageViewModel : PageViewModelBase
             {
                 SourceDns => LocalizationService.Get("Logs.TabDns"),
                 SourceEngine => EngineTabLabel,
+                SourceBridges => LocalizationService.Get("Logs.TabBridges"),
                 _ => LocalizationService.Get("Logs.TabApp")
             },
             Message = message,

--- a/OnionHop/src/OnionHopV3.App/Views/RelaysPageView.axaml
+++ b/OnionHop/src/OnionHopV3.App/Views/RelaysPageView.axaml
@@ -209,6 +209,21 @@
                                  Description="{DynamicResource Relays.EmptyDescription}"
                                  Icon="{x:Static mi:MaterialIconKind.ViewListOutline}"
                                  IsVisible="{Binding ShowNoResults}" />
+            <Border Grid.Row="1"
+                    Classes="InsetPanel"
+                    Margin="18"
+                    VerticalAlignment="Top"
+                    IsVisible="{Binding HasError}">
+              <TextBlock Text="{Binding ErrorText}"
+                         Foreground="{DynamicResource DangerBrush}"
+                         TextWrapping="Wrap" />
+            </Border>
+            <ProgressBar Grid.Row="1"
+                         IsIndeterminate="True"
+                         Height="3"
+                         Margin="10,0,18,0"
+                         VerticalAlignment="Top"
+                         IsVisible="{Binding IsLoading}" />
           </Grid>
         </Border>
       </Grid>

--- a/OnionHop/src/OnionHopV3.App/Views/SettingsPageView.axaml
+++ b/OnionHop/src/OnionHopV3.App/Views/SettingsPageView.axaml
@@ -235,6 +235,28 @@
                                     Description="{DynamicResource Settings.CustomDohHostWatermark}"
                                     ItemsSource="{Binding State.DnsProviders}"
                                     SelectedItem="{Binding State.SelectedDnsProviderChoice}" />
+              <Grid ColumnDefinitions="*,*"
+                    ColumnSpacing="12"
+                    IsVisible="{Binding State.IsCustomDoh}">
+                <controls:SettingRow Grid.Column="0"
+                                     Title="{DynamicResource Settings.CustomDohHost}"
+                                     Description="{DynamicResource Settings.CustomDohHostWatermark}">
+                  <controls:SettingRow.RowContent>
+                    <TextBox Width="260"
+                             Text="{Binding State.CustomDohHost}"
+                             Watermark="{DynamicResource Settings.CustomDohHostWatermark}" />
+                  </controls:SettingRow.RowContent>
+                </controls:SettingRow>
+                <controls:SettingRow Grid.Column="1"
+                                     Title="{DynamicResource Settings.CustomDohPath}"
+                                     Description="{DynamicResource Settings.CustomDohPathWatermark}">
+                  <controls:SettingRow.RowContent>
+                    <TextBox Width="160"
+                             Text="{Binding State.CustomDohPath}"
+                             Watermark="{DynamicResource Settings.CustomDohPathWatermark}" />
+                  </controls:SettingRow.RowContent>
+                </controls:SettingRow>
+              </Grid>
             </StackPanel>
           </Border>
 

--- a/OnionHop/src/OnionHopV3.App/app.manifest
+++ b/OnionHop/src/OnionHopV3.App/app.manifest
@@ -3,7 +3,7 @@
   <!-- This manifest is used on Windows only.
        Don't remove it as it might cause problems with window transparency and embedded controls.
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
-  <assemblyIdentity version="1.0.0.0" name="OnionHopV2.App.Desktop"/>
+  <assemblyIdentity version="1.0.0.0" name="OnionHopV3.App.Desktop"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/OnionHop/src/OnionHopV3.Cli/OnionHopV3.Cli.csproj
+++ b/OnionHop/src/OnionHopV3.Cli/OnionHopV3.Cli.csproj
@@ -21,6 +21,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
+    <None Include="..\..\..\OnionHop\artihop\**\*">
+      <Link>artihop\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="..\..\..\OnionHop\snowflake\**\*">
+      <Link>snowflake\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/OnionHop/src/OnionHopV3.Core/Dependencies/DependencyManager.cs
+++ b/OnionHop/src/OnionHopV3.Core/Dependencies/DependencyManager.cs
@@ -111,6 +111,12 @@ internal sealed class DependencyManager
             progress(new DependencyUpdate(false, "Components ready.", 1));
             return true;
         }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            log("Dependency download cancelled.");
+            progress(new DependencyUpdate(false, "Dependency download cancelled.", 0));
+            throw;
+        }
         catch (Exception ex)
         {
             log($"Dependency download failed: {ex.Message}");
@@ -324,6 +330,10 @@ internal sealed class DependencyManager
                 await DownloadWithFallbackAsync(client, candidates, torArchivePath, token).ConfigureAwait(false);
                 resolvedVersion = version;
                 break;
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -559,6 +569,10 @@ internal sealed class DependencyManager
                 await DownloadToFileAsync(client, url, targetPath, token).ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 lastUrl = url;
@@ -599,6 +613,10 @@ internal sealed class DependencyManager
                         .Take(10)
                         .Select(v => v.ToString()));
             }
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/OnionHop/src/OnionHopV3.Core/Platform/Linux/LinuxDnsProxyService.cs
+++ b/OnionHop/src/OnionHopV3.Core/Platform/Linux/LinuxDnsProxyService.cs
@@ -34,16 +34,20 @@ internal sealed class LinuxDnsProxyService : IDnsProxyService
 
             if (IsResolvectlAvailable())
             {
-                PlatformHelper.RunCommandSuccess("resolvectl", $"dns onionhop {safeNameServer}");
-                PlatformHelper.RunCommandSuccess("resolvectl", "domain onionhop ~onion");
+                if (!PlatformHelper.RunCommandSuccess("resolvectl", $"dns onionhop {safeNameServer}") ||
+                    !PlatformHelper.RunCommandSuccess("resolvectl", "domain onionhop ~onion"))
+                {
+                    log(".onion DNS proxying failed: resolvectl did not accept the onionhop link configuration.");
+                    return false;
+                }
+
                 log($".onion DNS proxying enabled via resolvectl (nameserver={safeNameServer}).");
                 _enabled = true;
                 return true;
             }
 
             log(".onion DNS proxying: resolvectl not available. Manual DNS configuration may be needed.");
-            _enabled = true;
-            return true;
+            return false;
         }
         catch (Exception ex)
         {

--- a/OnionHop/src/OnionHopV3.Core/Platform/Linux/LinuxKillSwitchService.cs
+++ b/OnionHop/src/OnionHopV3.Core/Platform/Linux/LinuxKillSwitchService.cs
@@ -21,18 +21,23 @@ internal sealed class LinuxKillSwitchService : IKillSwitchService
 
         try
         {
-            RunIptables($"-N {ChainName}");
-            RunIptables($"-F {ChainName}");
-            RunIptables($"-A {ChainName} -o lo -j ACCEPT");
-            RunIptables($"-A {ChainName} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT");
-            RunIptables($"-A {ChainName} -j DROP");
+            var ipv4Enabled = ConfigureIptablesFamily("iptables");
+            var ipv6Available = PlatformHelper.IsCommandAvailable("ip6tables");
+            var ipv6Enabled = ipv6Available && ConfigureIptablesFamily("ip6tables");
 
-            if (!ChainReferencedInOutput())
+            if (!ipv4Enabled)
             {
-                RunIptables($"-I OUTPUT 1 -j {ChainName}");
+                throw new InvalidOperationException("iptables did not accept the kill switch rules.");
             }
 
-            log("Kill switch engaged: outbound traffic blocked (iptables).");
+            if (ipv6Available && !ipv6Enabled)
+            {
+                log("IPv6 kill switch setup failed; IPv4 traffic is blocked. Disable IPv6 or use TUN/VPN mode for full leak protection.");
+            }
+
+            log(ipv6Enabled
+                ? "Kill switch engaged: outbound IPv4/IPv6 traffic blocked (iptables/ip6tables)."
+                : "Kill switch engaged: outbound IPv4 traffic blocked (iptables).");
         }
         catch (Exception ex)
         {
@@ -54,10 +59,9 @@ internal sealed class LinuxKillSwitchService : IKillSwitchService
 
         try
         {
-            RunIptables($"-D OUTPUT -j {ChainName}");
-            RunIptables($"-F {ChainName}");
-            RunIptables($"-X {ChainName}");
-            log("Kill switch cleared (iptables).");
+            ClearIptablesFamily("iptables");
+            ClearIptablesFamily("ip6tables");
+            log("Kill switch cleared (iptables/ip6tables).");
         }
         catch (Exception ex)
         {
@@ -74,7 +78,7 @@ internal sealed class LinuxKillSwitchService : IKillSwitchService
 
         try
         {
-            return ChainReferencedInOutput();
+            return ChainReferencedInOutput("iptables") || ChainReferencedInOutput("ip6tables");
         }
         catch
         {
@@ -82,14 +86,50 @@ internal sealed class LinuxKillSwitchService : IKillSwitchService
         }
     }
 
-    private static bool ChainReferencedInOutput()
+    private static bool ConfigureIptablesFamily(string command)
     {
-        var output = PlatformHelper.RunCommand("iptables", "-L OUTPUT -n");
-        return output != null && output.Contains(ChainName, StringComparison.Ordinal);
+        if (!PlatformHelper.IsCommandAvailable(command))
+        {
+            return false;
+        }
+
+        PlatformHelper.RunCommandSuccess(command, $"-N {ChainName}");
+        if (!PlatformHelper.RunCommandSuccess(command, $"-F {ChainName}"))
+        {
+            PlatformHelper.RunCommandSuccess(command, $"-X {ChainName}");
+            if (!PlatformHelper.RunCommandSuccess(command, $"-N {ChainName}") ||
+                !PlatformHelper.RunCommandSuccess(command, $"-F {ChainName}"))
+            {
+                return false;
+            }
+        }
+
+        if (!PlatformHelper.RunCommandSuccess(command, $"-A {ChainName} -o lo -j ACCEPT") ||
+            !PlatformHelper.RunCommandSuccess(command, $"-A {ChainName} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT") ||
+            !PlatformHelper.RunCommandSuccess(command, $"-A {ChainName} -j DROP"))
+        {
+            return false;
+        }
+
+        return ChainReferencedInOutput(command) ||
+               PlatformHelper.RunCommandSuccess(command, $"-I OUTPUT 1 -j {ChainName}");
     }
 
-    private static void RunIptables(string args)
+    private static void ClearIptablesFamily(string command)
     {
-        PlatformHelper.RunCommand("iptables", args);
+        if (!PlatformHelper.IsCommandAvailable(command))
+        {
+            return;
+        }
+
+        PlatformHelper.RunCommandSuccess(command, $"-D OUTPUT -j {ChainName}");
+        PlatformHelper.RunCommandSuccess(command, $"-F {ChainName}");
+        PlatformHelper.RunCommandSuccess(command, $"-X {ChainName}");
+    }
+
+    private static bool ChainReferencedInOutput(string command)
+    {
+        var output = PlatformHelper.RunCommand(command, "-L OUTPUT -n");
+        return output != null && output.Contains(ChainName, StringComparison.Ordinal);
     }
 }

--- a/OnionHop/src/OnionHopV3.Core/Platform/Windows/WindowsOnionDnsProxyService.cs
+++ b/OnionHop/src/OnionHopV3.Core/Platform/Windows/WindowsOnionDnsProxyService.cs
@@ -51,6 +51,8 @@ internal sealed class WindowsOnionDnsProxyService : IDnsProxyService
                 {
                     log($"WARNING: full DNS-over-Tor rule could not be installed ({ex.Message}). " +
                         "Normal DNS may leak to your ISP. Use TUN/VPN Mode for guaranteed leak-free DNS.");
+                    try { RemoveRule(_ => { }); } catch { }
+                    return false;
                 }
             }
             else

--- a/OnionHop/src/OnionHopV3.Core/Services/AdminHelperClient.cs
+++ b/OnionHop/src/OnionHopV3.Core/Services/AdminHelperClient.cs
@@ -24,6 +24,7 @@ internal enum AdminHelperConnectionKind
 
 internal sealed class AdminHelperClient : IDisposable
 {
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(30);
     private PipeStream? _pipe;
     private StreamReader? _reader;
     private StreamWriter? _writer;
@@ -273,17 +274,7 @@ internal sealed class AdminHelperClient : IDisposable
     {
         // Don't start helper just to check status - use existing connection only
         var response = await SendIfConnectedAsync("GetStatus", null).ConfigureAwait(false);
-        if (response?.Success != true)
-        {
-            return null;
-        }
-
-        if (response.Payload is JsonElement element)
-        {
-            return JsonSerializer.Deserialize<AdminHelperStatus>(element.GetRawText(), AdminHelperProtocol.JsonOptions);
-        }
-
-        return null;
+        return ParseStatusResponse(response);
     }
 
     public async Task<IReadOnlyList<string>> DrainLogsAsync()
@@ -448,7 +439,7 @@ internal sealed class AdminHelperClient : IDisposable
             _connectionKind = AdminHelperConnectionKind.PersistentDaemon;
             client = null;
 
-            var status = await GetStatusAsync().ConfigureAwait(false);
+            var status = ParseStatusResponse(await SendCoreWithoutLockAsync("GetStatus", null).ConfigureAwait(false));
             if (status?.IsAdministrator == true && string.Equals(status.Mode, "persistent", StringComparison.OrdinalIgnoreCase))
             {
                 StartupLogger.Write("AdminHelperClient: connected to persistent admin helper.");
@@ -663,11 +654,11 @@ internal sealed class AdminHelperClient : IDisposable
 
         var json = JsonSerializer.Serialize(request, AdminHelperProtocol.JsonOptions);
         StartupLogger.Write($"SendCoreAsync: Sending JSON ({json.Length} chars)...");
-        await _writer.WriteLineAsync(json).ConfigureAwait(false);
-        await _writer.FlushAsync().ConfigureAwait(false);
+        await _writer.WriteLineAsync(json).WaitAsync(CommandTimeout).ConfigureAwait(false);
+        await _writer.FlushAsync().WaitAsync(CommandTimeout).ConfigureAwait(false);
         StartupLogger.Write("SendCoreAsync: Waiting for response...");
 
-        var responseLine = await _reader.ReadLineAsync().ConfigureAwait(false);
+        var responseLine = await _reader.ReadLineAsync().WaitAsync(CommandTimeout).ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(responseLine))
         {
             StartupLogger.Write("SendCoreAsync: Empty response received");
@@ -676,6 +667,21 @@ internal sealed class AdminHelperClient : IDisposable
 
         StartupLogger.Write($"SendCoreAsync: Response received ({responseLine.Length} chars)");
         return JsonSerializer.Deserialize<HelperResponse>(responseLine, AdminHelperProtocol.JsonOptions);
+    }
+
+    private static AdminHelperStatus? ParseStatusResponse(HelperResponse? response)
+    {
+        if (response?.Success != true)
+        {
+            return null;
+        }
+
+        if (response.Payload is JsonElement element)
+        {
+            return JsonSerializer.Deserialize<AdminHelperStatus>(element.GetRawText(), AdminHelperProtocol.JsonOptions);
+        }
+
+        return null;
     }
 
     private static NamedPipeServerStream CreateServerPipe(string pipeName)

--- a/OnionHop/src/OnionHopV3.Core/Services/ArtiService.cs
+++ b/OnionHop/src/OnionHopV3.Core/Services/ArtiService.cs
@@ -236,7 +236,13 @@ internal sealed class ArtiService : IDisposable
         foreach (var plugin in config.TransportPlugins ?? Array.Empty<string>())
         {
             var parsed = ParseTransportPlugin(plugin);
-            if (parsed is not var (transport, path) || !seen.Add(transport))
+            if (parsed == null)
+            {
+                continue;
+            }
+
+            var (transport, path, arguments) = parsed.Value;
+            if (!seen.Add(transport))
             {
                 continue;
             }
@@ -249,14 +255,20 @@ internal sealed class ArtiService : IDisposable
             {
                 continue;
             }
-            sb.Append($"\n[[bridges.transports]]\nprotocols = [{protocols}]\npath = \"{EscapeTomlString(path)}\"\nrun_on_startup = false\n");
+            sb.Append($"\n[[bridges.transports]]\nprotocols = [{protocols}]\npath = \"{EscapeTomlString(path)}\"\n");
+            if (arguments.Count > 0)
+            {
+                var args = string.Join(", ", arguments.Select(argument => $"\"{EscapeTomlString(argument)}\""));
+                sb.Append($"arguments = [{args}]\n");
+            }
+            sb.Append("run_on_startup = false\n");
         }
 
         return sb.ToString();
     }
 
-    // Parse a Tor-format "transport exec C:\path\to\client.exe [args]" line into (transport, path).
-    internal static (string Transport, string Path)? ParseTransportPlugin(string? plugin)
+    // Parse a Tor-format "transport exec C:\path\to\client.exe [args]" line into Arti fields.
+    internal static (string Transport, string Path, IReadOnlyList<string> Arguments)? ParseTransportPlugin(string? plugin)
     {
         if (string.IsNullOrWhiteSpace(plugin))
         {
@@ -283,21 +295,70 @@ internal sealed class ArtiService : IDisposable
             return null;
         }
 
-        // PT exec lines OnionHop generates carry just the path (no trailing args), but be defensive: a
-        // quoted path is taken verbatim, otherwise take the whole remainder as the path (TOML-escaped
-        // later, so embedded spaces are fine).
         string path;
+        IReadOnlyList<string> arguments;
         if (rest.StartsWith('"'))
         {
             var end = rest.IndexOf('"', 1);
             path = end > 1 ? rest[1..end] : rest.Trim('"');
+            arguments = SplitCommandLineArguments(end > 1 ? rest[(end + 1)..] : string.Empty);
         }
         else
         {
-            path = rest;
+            var parts = SplitCommandLineArguments(rest);
+            var firstArgument = parts.FindIndex(argument => argument.StartsWith("-", StringComparison.Ordinal));
+            if (firstArgument > 0)
+            {
+                path = string.Join(' ', parts.Take(firstArgument));
+                arguments = parts.Skip(firstArgument).ToList();
+            }
+            else
+            {
+                path = rest;
+                arguments = Array.Empty<string>();
+            }
         }
 
-        return path.Length == 0 ? null : (transport, path);
+        return path.Length == 0 ? null : (transport, path, arguments);
+    }
+
+    private static List<string> SplitCommandLineArguments(string value)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return result;
+        }
+
+        var current = new StringBuilder();
+        var inQuotes = false;
+        foreach (var ch in value.Trim())
+        {
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(ch) && !inQuotes)
+            {
+                if (current.Length > 0)
+                {
+                    result.Add(current.ToString());
+                    current.Clear();
+                }
+                continue;
+            }
+
+            current.Append(ch);
+        }
+
+        if (current.Length > 0)
+        {
+            result.Add(current.ToString());
+        }
+
+        return result;
     }
 
     private static async Task<bool> WaitForSocksPortReadyAsync(

--- a/OnionHop/src/OnionHopV3.Core/Tor/TorBridgeManager.cs
+++ b/OnionHop/src/OnionHopV3.Core/Tor/TorBridgeManager.cs
@@ -863,6 +863,10 @@ internal sealed class TorBridgeManager
                 }
             }
         }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             log($"Bridge auto-fetch for {bridgeType} failed: {ex.Message}");
@@ -1956,6 +1960,11 @@ internal sealed class TorBridgeManager
                 .ToList();
         }
 
+        if (string.Equals(normalizedType, "custom", StringComparison.OrdinalIgnoreCase))
+        {
+            return NormalizeCustomBridgeLines(lines, log);
+        }
+
         var updated = false;
         var result = new List<string>(lines.Count);
         foreach (var line in lines)
@@ -1999,6 +2008,68 @@ internal sealed class TorBridgeManager
         }
 
         return result;
+    }
+
+    private static IReadOnlyList<string> NormalizeCustomBridgeLines(IReadOnlyList<string> lines, Action<string> log)
+    {
+        var updated = false;
+        var result = new List<string>(lines.Count);
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            var firstToken = ExtractBridgeTransport(trimmed);
+            if (string.Equals(firstToken, VanillaBridgeType, StringComparison.OrdinalIgnoreCase))
+            {
+                var vanilla = NormalizeVanillaBridgeLine(trimmed);
+                if (IsValidVanillaBridgeLine(vanilla))
+                {
+                    result.Add(vanilla);
+                    updated = true;
+                }
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(firstToken))
+            {
+                if (LooksLikeEndpoint(trimmed) && IsValidVanillaBridgeLine(trimmed))
+                {
+                    result.Add(trimmed);
+                }
+                else
+                {
+                    log($"Ignoring invalid bridge line: {trimmed}");
+                }
+                continue;
+            }
+
+            if (LooksLikeEndpoint(firstToken))
+            {
+                var vanilla = NormalizeVanillaBridgeLine(trimmed);
+                if (IsValidVanillaBridgeLine(vanilla))
+                {
+                    result.Add(vanilla);
+                }
+                else
+                {
+                    log($"Ignoring invalid bridge line: {trimmed}");
+                }
+                continue;
+            }
+
+            result.Add(trimmed);
+        }
+
+        if (updated)
+        {
+            log("Normalized custom vanilla bridge lines.");
+        }
+
+        return result.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     private static bool LooksLikeEndpoint(string token)

--- a/OnionHop/src/OnionHopV3.Tests/Services/ArtiBridgeConfigTests.cs
+++ b/OnionHop/src/OnionHopV3.Tests/Services/ArtiBridgeConfigTests.cs
@@ -121,6 +121,43 @@ public sealed class ArtiBridgeConfigTests
             Assert.NotNull(parsed);
             Assert.Equal(expectedTransport, parsed!.Value.Transport);
             Assert.Equal(expectedPath, parsed.Value.Path);
+            Assert.Empty(parsed.Value.Arguments);
         }
+    }
+
+    [Fact]
+    public void BuildBridgesSection_EmitsTransportArguments()
+    {
+        var config = new ArtiLaunchConfig
+        {
+            ArtiPath = "arti",
+            SocksPort = 9050,
+            BridgeLines = new[]
+            {
+                "conjure 1.2.3.4:443 ABCDEF0123456789ABCDEF0123456789ABCDEF01",
+            },
+            TransportPlugins = new[]
+            {
+                "ClientTransportPlugin conjure exec /opt/onionhop/conjure-client -registerURL https://registration.refraction.network/api",
+            },
+        };
+
+        var toml = ArtiService.BuildBridgesSection(config);
+
+        Assert.Contains("protocols = [\"conjure\"]", toml);
+        Assert.Contains("path = \"/opt/onionhop/conjure-client\"", toml);
+        Assert.Contains("arguments = [\"-registerURL\", \"https://registration.refraction.network/api\"]", toml);
+    }
+
+    [Fact]
+    public void ParseTransportPlugin_SplitsQuotedPathAndArguments()
+    {
+        var parsed = ArtiService.ParseTransportPlugin(
+            "ClientTransportPlugin snowflake exec \"/Applications/Onion Hop/lyrebird\" -ampcache https://cdn.ampproject.org/");
+
+        Assert.NotNull(parsed);
+        Assert.Equal("snowflake", parsed!.Value.Transport);
+        Assert.Equal("/Applications/Onion Hop/lyrebird", parsed.Value.Path);
+        Assert.Equal(new[] { "-ampcache", "https://cdn.ampproject.org/" }, parsed.Value.Arguments);
     }
 }

--- a/OnionHop/src/OnionHopV3.Tests/Tor/TorBridgeManagerTests.cs
+++ b/OnionHop/src/OnionHopV3.Tests/Tor/TorBridgeManagerTests.cs
@@ -234,6 +234,33 @@ public sealed class TorBridgeManagerTests
     }
 
     [Fact]
+    public async Task GetBridgeLinesAsync_custom_vanilla_lines_stay_vanilla()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var manager = new TorBridgeManager(dir);
+            var options = new OnionHopConnectOptions
+            {
+                SelectedBridgeType = "custom",
+                CustomBridges = "8.8.8.8:443 74FAD13168806246602538555B5521A0383A1875"
+            };
+
+            var lines = await manager.GetBridgeLinesAsync(options, null, _ => { }, CancellationToken.None);
+            var plugins = manager.GetClientTransportPlugins(options, lines, Path.Combine(dir, "tor"), null, _ => { });
+
+            Assert.Single(lines);
+            Assert.Equal("8.8.8.8:443 74FAD13168806246602538555B5521A0383A1875", lines[0]);
+            Assert.Empty(plugins);
+            Assert.False(TorBridgeManager.BridgeLinesNeedClientTransportPlugins(lines));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
     public void GetBridgeTypeKeys_includes_conjure_when_transport_exists()
     {
         var config = new PluggableTransportConfig

--- a/OnionHop/tor/pluggable_transports/pt_config.json
+++ b/OnionHop/tor/pluggable_transports/pt_config.json
@@ -3,7 +3,7 @@
     "pluggableTransports":  {
                                 "snowflake":  "ClientTransportPlugin snowflake exec ${pt_path}lyrebird.exe",
                                 "lyrebird":  "ClientTransportPlugin meek_lite,obfs2,obfs3,obfs4,scramblesuit exec ${pt_path}lyrebird.exe",
-                                "conjure":  "ClientTransportPlugin conjure exec ${pt_path}lyrebird.exe",
+                                "conjure":  "ClientTransportPlugin conjure exec ${pt_path}conjure-client.exe -registerURL https://registration.refraction.network/api",
                                 "webtunnel":  "ClientTransportPlugin webtunnel exec ${pt_path}webtunnel-client.exe"
                             },
     "bridges":  {

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@
 V3 is a ground-up rebuild on a new cross-platform UI stack, with a much smarter connection engine and a far wider set of censorship-resistant transports.
 
 - **Now cross-platform** — native desktop builds for **Windows**, **macOS** (signed & notarized universal app) and **Linux** (AppImage). Same app, native look on each OS.
-- **Redesigned UI** — Fluent/native look (FluentAvalonia), light/dark/follow-system themes, an accent picker, an integrated chromeless title bar on Windows and native window chrome on macOS, and **5 languages** (English, German, French, Chinese, Russian).
+- **Redesigned UI** — Fluent/native look (FluentAvalonia), light/dark/follow-system themes, an accent picker, an integrated chromeless title bar on Windows and native window chrome on macOS, and **8 languages** (English, German, French, Chinese, Russian, Persian, Azerbaijani, and Sorani Kurdish).
 - **Smart Connect** — an offline censorship "brain" that auto-picks the best connection strategy for your network and country: it knows where Tor is blocked, prefers transports that survive there, pre-tests bridge reachability, races strategies in parallel, fails fast off dead paths, and remembers what worked on each network so the next connect is instant.
-- **Three Tor engines** — **Classic** (`tor.exe`, full control: bridges, country/entry/exit pinning, control-port New Identity), **Arti** (the Rust Tor implementation), and **ArtiHop** (shortened 2-hop Guard→Exit circuits for lower latency, with live New Identity).
+- **Three Tor engines** — **Classic** (`tor.exe`, full control: bridges, country/entry/exit pinning, control-port New Identity), **Arti** (the Rust Tor implementation with native bridge/PT config), and **ArtiHop** (shortened 2-hop Guard→Exit circuits for lower latency).
 - **More censorship-resistant transports** — obfs4, **snowflake** (with optional AMP-cache fronting), **webtunnel**, **conjure**, meek, and **dnstt** (a DNS tunnel that gets Tor through when only DNS is allowed).
 - **Bridge Scanner** — fetch and reachability-test bridges of every transport, see color-coded latency, and one-click apply the ones that actually work on your network.
 - **More bridge sources** — the official Tor bridge service, the censorship-resistant [OnionHop Bridges Collector](https://github.com/center2055/OnionHop-Bridges-Collector) (derived from [Delta-Kronecker/Tor-Bridges-Collector](https://github.com/Delta-Kronecker/Tor-Bridges-Collector)), built-in community bridges, and a thin-set top-up so a tiny live fetch is automatically backed by bundled bridges.
 - **Relays browser** — search the live Tor relay list by nickname, country, role, flags and bandwidth, and pin a preferred entry/middle/exit.
-- **Command-line interface** — a full-featured TUI (`OnionHopV3.Cli`) with a live status dashboard, connect/scan/bridges/snowflake/relays commands and settings persistence. *(Windows now; Linux & macOS CLI coming soon.)*
+- **Command-line interface** — a full-featured TUI (`OnionHopV3.Cli`) with a live status dashboard, connect/scan/bridges/snowflake/relays commands and settings persistence. Windows and Linux packages are built by CI.
 - **Stronger leak protection** — optional full DNS-over-Tor, a kill switch, UDP blocking in TUN mode, and an in-app WebRTC/UDP privacy notice.
 - **Volunteer as a Snowflake proxy** — help censored users reach Tor, straight from Settings.
 - **Quality-of-life** — decoupled system-proxy toggle (turn it off while Tor stays connected), an opt-in persistent admin helper to skip repeat UAC prompts in TUN mode (off by default), an in-app changelog, and Bitcoin donations.
@@ -58,8 +58,9 @@ Grab the latest build for your platform from **[Releases](https://github.com/cen
 | **Windows** | `OnionHop-Setup-v3.exe` | Installer (self-contained, .NET runtime bundled) |
 | **Windows** | `OnionHopV3-Portable-…win-x64.zip` | Portable, no install |
 | **Linux** | `OnionHop-x86_64.AppImage` | `chmod +x` and run |
-| **macOS** | `OnionHop-3.1.0-macOS.dmg` | Signed & notarized; universal (Apple Silicon + Intel) — from the [macOS repo](https://github.com/rana-gmbh/onionhopMac/releases/latest) |
-| **Windows CLI** | `OnionHop-CLI-Setup-3.1.0.exe` / `…Portable…zip` | Terminal interface |
+| **macOS** | `OnionHop-3.x-macOS.dmg` | Signed & notarized; universal (Apple Silicon + Intel) — from the [macOS repo](https://github.com/rana-gmbh/onionhopMac/releases/latest) |
+| **Windows CLI** | `OnionHop-CLI-Setup-3.x.exe` / portable ZIP | Terminal interface |
+| **Linux CLI** | `OnionHopCLI-…linux-x64.tar.gz` | Terminal interface |
 
 > The macOS `.dmg` is published from the dedicated, code-signing [rana-gmbh/onionhopMac](https://github.com/rana-gmbh/onionhopMac/releases/latest) repository.
 
@@ -80,7 +81,7 @@ Grab the latest build for your platform from **[Releases](https://github.com/cen
 
 Notes
 - `.onion` sites require a Tor-aware client (Tor Browser recommended) or SOCKS remote DNS (e.g., Firefox "Proxy DNS when using SOCKS v5").
-- Bridges, country/relay pinning and control-port New Identity require the **Classic** engine today — the **Arti**/**ArtiHop** engines run bridgeless in OnionHop for now (native bridge support is planned; upstream Arti itself supports bridges).
+- Country/relay pinning and control-port New Identity require the **Classic** engine. Arti and ArtiHop support OnionHop bridge/PT configuration, but Classic remains the most complete choice for manual circuit control.
 
 ---
 
@@ -88,11 +89,11 @@ Notes
 
 | Engine | Hops | Admin | Bridges / pinning / NEWNYM | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| **Classic** (`tor.exe`) | 3 | no (Proxy) | yes | Most features; recommended for censorship + control |
-| **Arti** | 3 | no | not yet in OnionHop | Rust Tor implementation (SOCKS runtime) |
-| **ArtiHop** | 2 (Guard→Exit) | no | New Identity only | Lower latency, weaker anonymity |
+| **Classic** (`tor.exe`) | 3 | no (Proxy) | bridges, pinning, NEWNYM | Most features; recommended for censorship + manual circuit control |
+| **Arti** | 3 | no | bridges/PT | Rust Tor implementation (SOCKS runtime) |
+| **ArtiHop** | 2 (Guard→Exit) | no | bridges/PT | Lower latency, weaker anonymity |
 
-> Upstream **Arti** supports bridges and pluggable transports, but OnionHop currently runs its **Arti** and **ArtiHop** engines as a plain SOCKS runtime without bridge/PT config — so use the **Classic** engine for bridged/censored networks. Native bridge support for the Arti engines is planned for a future release.
+Use **Classic** when you need country pinning, relay pinning, or control-port New Identity. Use **Arti** or **ArtiHop** when you want the Rust runtime and do not need those Classic-only controls.
 
 ---
 
@@ -133,7 +134,7 @@ Fetch runtime dependencies (Tor, pluggable transports, sing-box, Wintun, ArtiHop
 powershell -NoProfile -ExecutionPolicy Bypass -File download-deps.ps1
 ```
 ```bash
-# macOS / Linux
+# Linux
 ./download-deps.sh
 ```
 

--- a/download-deps.ps1
+++ b/download-deps.ps1
@@ -631,11 +631,11 @@ try {
         if ($null -ne $ptConfig.pluggableTransports) {
             if ($ptConfig.pluggableTransports -is [System.Collections.IDictionary]) {
                 $ptConfig.pluggableTransports["lyrebird"] = "ClientTransportPlugin meek_lite,obfs2,obfs3,obfs4,scramblesuit exec `${pt_path}lyrebird.exe"
-                $ptConfig.pluggableTransports["conjure"] = "ClientTransportPlugin conjure exec `${pt_path}lyrebird.exe"
+                $ptConfig.pluggableTransports["conjure"] = "ClientTransportPlugin conjure exec `${pt_path}conjure-client.exe -registerURL https://registration.refraction.network/api"
                 $ptConfig.pluggableTransports["webtunnel"] = "ClientTransportPlugin webtunnel exec `${pt_path}webtunnel-client.exe"
             } else {
                 $ptConfig.pluggableTransports | Add-Member -NotePropertyName "lyrebird" -NotePropertyValue "ClientTransportPlugin meek_lite,obfs2,obfs3,obfs4,scramblesuit exec `${pt_path}lyrebird.exe" -Force
-                $ptConfig.pluggableTransports | Add-Member -NotePropertyName "conjure" -NotePropertyValue "ClientTransportPlugin conjure exec `${pt_path}lyrebird.exe" -Force
+                $ptConfig.pluggableTransports | Add-Member -NotePropertyName "conjure" -NotePropertyValue "ClientTransportPlugin conjure exec `${pt_path}conjure-client.exe -registerURL https://registration.refraction.network/api" -Force
                 $ptConfig.pluggableTransports | Add-Member -NotePropertyName "webtunnel" -NotePropertyValue "ClientTransportPlugin webtunnel exec `${pt_path}webtunnel-client.exe" -Force
             }
         }


### PR DESCRIPTION
This PR tightens several reliability paths around bridge startup, helper IPC, DNS/killswitch setup, and packaging.
Key changes:
Fixes persistent admin-helper status probing to avoid re-entering the same IPC lock, with bounded helper command timeouts.
Preserves Arti/ArtiHop pluggable transport arguments, including Conjure registration flags.
Prevents custom vanilla bridge lines from being rewritten as a fake custom transport.
Improves cancellation behavior for dependency and bridge fetch paths.
Hardens DNS and Linux kill-switch setup so failures are reported instead of treated as success.
Adds missing custom DoH fields, relay loading/error states, bridge log labeling, and shared button styles.
Includes ArtiHop/Snowflake runtime folders in CLI publish output.
Updates docs/changelog and adds package workflow test gates plus release checksum uploads.